### PR TITLE
Use redis instead of PostgreSQL LISTEN/NOTIFY

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ psycopg[binary]==3.1.12
 django-ninja==0.22.2
 whitenoise==6.6.0
 environs[django]==9.5.0
+gunicorn==21.2.0
+redis==5.0.1
 uvicorn==0.23.2
 pyjwt==2.6.0
 daphne==4.0.0

--- a/voxpop/signals.py
+++ b/voxpop/signals.py
@@ -77,6 +77,7 @@ def notify_question_created(sender, instance, created, **kwargs):
             data=json.dumps(payload),
             channel_name=channel_name,
         )
+
         if instance.state == Question.State.APPROVED:
             notify(channel_name=channel_name, payload=message)
         channel_name = get_notify_channel_name(

--- a/voxpop/signals.py
+++ b/voxpop/signals.py
@@ -77,7 +77,6 @@ def notify_question_created(sender, instance, created, **kwargs):
             data=json.dumps(payload),
             channel_name=channel_name,
         )
-
         if instance.state == Question.State.APPROVED:
             notify(channel_name=channel_name, payload=message)
         channel_name = get_notify_channel_name(

--- a/voxpop/utils.py
+++ b/voxpop/utils.py
@@ -19,5 +19,18 @@ def notify(*, channel_name: str, payload: Message) -> None:
     r.publish(channel=channel_name, message=str(payload))
 
 
-def get_async_redis_connection() -> redis.Redis:
-    return async_redis.from_url(url=settings.REDIS_URL)
+class RedisPool:
+    _pool = None
+
+    @classmethod
+    def get_pool(cls):
+        """Return a connection pool for Redis."""
+        if not cls._pool:
+            cls._pool = async_redis.ConnectionPool.from_url(url=settings.REDIS_URL)
+        return cls._pool
+
+
+def get_async_redis_connection() -> async_redis.Redis:
+    """Return an async Redis connection."""
+    pool = RedisPool.get_pool()
+    return async_redis.Redis(connection_pool=pool)

--- a/voxpop/utils.py
+++ b/voxpop/utils.py
@@ -1,7 +1,10 @@
 from uuid import UUID
 
-import psycopg
-from django.db import connection
+import redis
+import redis.asyncio as async_redis
+from django.conf import settings
+
+from voxpop.models import Message
 
 
 def get_notify_channel_name(*, voxpop_id: UUID, channel_prefix: str = "") -> str:
@@ -11,12 +14,10 @@ def get_notify_channel_name(*, voxpop_id: UUID, channel_prefix: str = "") -> str
     return f"{channel_prefix}questions_{voxpop_id.hex}"
 
 
-def notify(*, channel_name: str, payload: str):
-    conn = psycopg.connect(
-        **connection.get_connection_params(),
-        autocommit=True,
-    )
-    with conn.cursor() as cursor:
-        cursor.execute(
-            f"NOTIFY {channel_name}, '{payload}'",
-        )
+def notify(*, channel_name: str, payload: Message) -> None:
+    r = redis.from_url(url=settings.REDIS_URL)
+    r.publish(channel=channel_name, message=str(payload))
+
+
+def get_async_redis_connection() -> redis.Redis:
+    return async_redis.from_url(url=settings.REDIS_URL)

--- a/voxpop/views.py
+++ b/voxpop/views.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncIterator
 from uuid import UUID
 
 import jwt
@@ -223,7 +223,7 @@ async def __stream_questions(
     channel_prefix: str,
     voxpop_id: UUID,
     last_event_id: int,
-) -> AsyncGenerator[str, None]:
+) -> AsyncIterator[str]:
     channel_name = get_notify_channel_name(
         channel_prefix=channel_prefix,
         voxpop_id=voxpop_id,

--- a/voxpop_project/settings.py
+++ b/voxpop_project/settings.py
@@ -17,7 +17,8 @@ SECRET_KEY = env.str("SECRET_KEY")
 DEBUG = env.bool("DEBUG", default=False)
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 CSRF_TRUSTED_ORIGINS = CORS_ORIGIN_WHITELIST = env.list("CSRF_TRUSTED_ORIGINS")
-PLUGON_HOSTNAME = env.str("PLUGON_HOSTNAME")
+PLUGON_HOSTNAME = env.str("PLUGON_HOSTNAME", default="")
+REDIS_URL = env.str("REDIS_URL", default="redis://localhost:6379/0")
 
 # Application definition
 


### PR DESCRIPTION
This swaps out the PostgreSQL LISTEN/NOTIFY machinery with using Redis.

Running using `./manage.py runserver` (with daphne) has some problems with requests hanging with multiple clients.

Running using a combination of `gunicorn` and `uvicorn` works quite well (uses 32 workers, but can be adjusted - gunicorn docs recommend `2-4 x $(NUM_CORES)` https://docs.gunicorn.org/en/stable/settings.html#workers):

```
python -m gunicorn voxpop_project.asgi:application -w 32 -k uvicorn.workers.UvicornWorker
```

Keep in mind that, using HTTP/1.1, browsers can only maintain 6 concurrent connections using Server Sent Events. This has confused med somewhat testing this. See the warning on https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#listening_for_custom_events for more info. 